### PR TITLE
feat: ibc timeout test case

### DIFF
--- a/chainset.go
+++ b/chainset.go
@@ -102,7 +102,7 @@ func (cs *chainSet) CreateCommonAccount(ctx context.Context, keyName string) (fa
 }
 
 // Start concurrently calls Start against each chain in the set.
-func (cs *chainSet) Start(ctx context.Context, testName string, additionalGenesisWallets map[ibc.Chain][]ibc.WalletAmount) error {
+func (cs *chainSet) Start(ctx context.Context, testName string, additionalGenesisWallets map[ibc.Chain][]ibc.WalletData) error {
 	for c := range cs.chains {
 		c := c
 		if c.Config().Type == "rollapp" {

--- a/cosmos/cosmos_chain.go
+++ b/cosmos/cosmos_chain.go
@@ -310,7 +310,7 @@ func (c *CosmosChain) BuildRelayerWallet(ctx context.Context, keyName string) (i
 }
 
 // Implements Chain interface
-func (c *CosmosChain) SendFunds(ctx context.Context, keyName string, amount ibc.WalletAmount) error {
+func (c *CosmosChain) SendFunds(ctx context.Context, keyName string, amount ibc.WalletData) error {
 	return c.getFullNode().SendFunds(ctx, keyName, amount)
 }
 
@@ -319,10 +319,10 @@ func (c *CosmosChain) SendIBCTransfer(
 	ctx context.Context,
 	channelID string,
 	keyName string,
-	amount ibc.WalletAmount,
+	toWallet ibc.WalletData,
 	options ibc.TransferOptions,
 ) (tx ibc.Tx, _ error) {
-	txHash, err := c.getFullNode().SendIBCTransfer(ctx, channelID, keyName, amount, options)
+	txHash, err := c.getFullNode().SendIBCTransfer(ctx, channelID, keyName, toWallet, options)
 	if err != nil {
 		return tx, fmt.Errorf("send ibc transfer: %w", err)
 	}
@@ -723,7 +723,7 @@ type ValidatorWithIntPower struct {
 var keyDir string
 
 // StartHub bootstraps the hubs and starts it from genesis
-func (c *CosmosChain) StartHub(testName string, ctx context.Context, seq string, additionalGenesisWallets ...ibc.WalletAmount) error {
+func (c *CosmosChain) StartHub(testName string, ctx context.Context, seq string, additionalGenesisWallets ...ibc.WalletData) error {
 	chainCfg := c.Config()
 
 	decimalPow := int64(math.Pow10(int(*chainCfg.CoinDecimals)))
@@ -934,7 +934,7 @@ func (c *CosmosChain) StartHub(testName string, ctx context.Context, seq string,
 		return err
 	}
 	amount := sdkmath.NewInt(10_000_000_000_000)
-	fund := ibc.WalletAmount{
+	fund := ibc.WalletData{
 		Address: sequencer,
 		Denom:   c.Config().Denom,
 		Amount:  amount,
@@ -952,7 +952,7 @@ func (c *CosmosChain) StartHub(testName string, ctx context.Context, seq string,
 }
 
 // CreateRollapp bootstraps the hubs
-func (c *CosmosChain) CreateRollapp(testName string, ctx context.Context, additionalGenesisWallets ...ibc.WalletAmount) (string, error) {
+func (c *CosmosChain) CreateRollapp(testName string, ctx context.Context, additionalGenesisWallets ...ibc.WalletData) (string, error) {
 	chainCfg := c.Config()
 
 	decimalPow := int64(math.Pow10(int(*chainCfg.CoinDecimals)))
@@ -1125,7 +1125,7 @@ func (c *CosmosChain) CreateRollapp(testName string, ctx context.Context, additi
 }
 
 // StartRollapp start the Rollapps from genesis
-func (c *CosmosChain) StartRollapp(testName string, ctx context.Context, additionalGenesisWallets ...ibc.WalletAmount) error {
+func (c *CosmosChain) StartRollapp(testName string, ctx context.Context, additionalGenesisWallets ...ibc.WalletData) error {
 	nodes := c.Nodes()
 
 	if err := nodes.LogGenesisHashes(ctx); err != nil {

--- a/cosmos/node.go
+++ b/cosmos/node.go
@@ -744,12 +744,12 @@ func (node *Node) SendIBCTransfer(
 	ctx context.Context,
 	channelID string,
 	keyName string,
-	amount ibc.WalletAmount,
+	toWallet ibc.WalletData,
 	options ibc.TransferOptions,
 ) (string, error) {
 	command := []string{
 		"ibc-transfer", "transfer", "transfer", channelID,
-		amount.Address, fmt.Sprintf("%s%s", amount.Amount.String(), amount.Denom),
+		toWallet.Address, fmt.Sprintf("%s%s", toWallet.Amount.String(), toWallet.Denom),
 		"--gas", "auto",
 	}
 	if options.Timeout != nil {
@@ -765,10 +765,10 @@ func (node *Node) SendIBCTransfer(
 	return node.ExecTx(ctx, keyName, command...)
 }
 
-func (node *Node) SendFunds(ctx context.Context, keyName string, amount ibc.WalletAmount) error {
+func (node *Node) SendFunds(ctx context.Context, keyName string, toWallet ibc.WalletData) error {
 	_, err := node.ExecTx(ctx,
 		keyName, "bank", "send", keyName,
-		amount.Address, fmt.Sprintf("%s%s", amount.Amount.String(), amount.Denom),
+		toWallet.Address, fmt.Sprintf("%s%s", toWallet.Amount.String(), toWallet.Denom),
 		"--broadcast-mode", "block",
 	)
 	return err

--- a/cosmos/poll.go
+++ b/cosmos/poll.go
@@ -68,7 +68,7 @@ func PollForMessage[T any](ctx context.Context, chain *CosmosChain, registry cod
 }
 
 // PollForBalance polls until the balance matches
-func PollForBalance(ctx context.Context, chain *CosmosChain, deltaBlocks uint64, balance ibc.WalletAmount) error {
+func PollForBalance(ctx context.Context, chain *CosmosChain, deltaBlocks uint64, balance ibc.WalletData) error {
 	h, err := chain.Height(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get height: %w", err)

--- a/example/setup.go
+++ b/example/setup.go
@@ -39,6 +39,10 @@ var (
 	}
 )
 
+func GetDymensionConfig() (config ibc.ChainConfig) {
+	return dymensionConfig
+}
+
 // GetDockerImageInfo returns the appropriate repo and branch version string for integration with the CI pipeline.
 // The remote runner sets the BRANCH_CI env var. If present, tests will use the docker image pushed up to the repo.
 // If testing locally, user should run `make docker-build-debug` and tests will use the local image.

--- a/ibc/chain.go
+++ b/ibc/chain.go
@@ -15,13 +15,13 @@ type Chain interface {
 	Initialize(ctx context.Context, testName string, cli *client.Client, networkID string) error
 
 	// StartHub sets up everything needed (validators, gentx, fullnodes, peering, additional accounts) for Hub to start from genesis.
-	StartHub(testName string, ctx context.Context, seq string, additionalGenesisWallets ...WalletAmount) error
+	StartHub(testName string, ctx context.Context, seq string, additionalGenesisWallets ...WalletData) error
 
 	// CreateRollapp sets up everything needed (validators, gentx, fullnodes, peering, additional accounts) for Rollapp from genesis.
-	CreateRollapp(testName string, ctx context.Context, additionalGenesisWallets ...WalletAmount) (string, error)
+	CreateRollapp(testName string, ctx context.Context, additionalGenesisWallets ...WalletData) (string, error)
 
 	// StartRollapp start everything (validators, gentx, fullnodes, peering, additional accounts).
-	StartRollapp(testName string, ctx context.Context, additionalGenesisWallets ...WalletAmount) error
+	StartRollapp(testName string, ctx context.Context, additionalGenesisWallets ...WalletData) error
 	// Exec runs an arbitrary command using Chain's docker environment.
 	// Whether the invoked command is run in a one-off container or execing into an already running container
 	// is up to the chain implementation.
@@ -63,10 +63,10 @@ type Chain interface {
 	GetAddress(ctx context.Context, keyName string) ([]byte, error)
 
 	// SendFunds sends funds to a wallet from a user account.
-	SendFunds(ctx context.Context, keyName string, amount WalletAmount) error
+	SendFunds(ctx context.Context, keyName string, amount WalletData) error
 
 	// SendIBCTransfer sends an IBC transfer returning a transaction or an error if the transfer failed.
-	SendIBCTransfer(ctx context.Context, channelID, keyName string, amount WalletAmount, options TransferOptions) (Tx, error)
+	SendIBCTransfer(ctx context.Context, channelID, keyName string, amount WalletData, options TransferOptions) (Tx, error)
 
 	// Height returns the current block height or an error if unable to get current height.
 	Height(ctx context.Context) (uint64, error)

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -239,7 +239,7 @@ func (i DockerImage) Ref() string {
 	return i.Repository + ":" + i.Version
 }
 
-type WalletAmount struct {
+type WalletData struct {
 	Address string
 	Denom   string
 	Amount  math.Int

--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -1,0 +1,16 @@
+package testutil
+
+import (
+	"context"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/decentrio/rollup-e2e-testing/ibc"
+	"github.com/stretchr/testify/require"
+)
+
+func AssertBalance(t *testing.T, ctx context.Context, chain ibc.Chain, address string, denom string, expectedBalance sdkmath.Int) {
+	balance, err := chain.GetBalance(ctx, address, denom)
+	require.NoError(t, err)
+	require.Equal(t, expectedBalance, balance)
+}


### PR DESCRIPTION
A test case  under `e2e-tests/ibc` folder that verifies the system's behaviour in case of IBC packet timeout.
The timeout is defined in the following way:
```
	options := ibc.TransferOptions{
		Timeout: &ibc.IBCTimeout{
			NanoSeconds: 1000000, // 1 ms - this will cause the transfer to timeout before it is picked by a relayer
		},
	}
```
Other updates:
* `AssertBalance` function in `testutil` package to assert wallet balances
* `ibc.WalletAmount` structure is now named `ibc.WalletData`
