### PR TITLE
Add ExtraFlags when starting the chain

### DIFF
--- a/chainfactory.go
+++ b/chainfactory.go
@@ -100,7 +100,7 @@ func (f *BuiltinChainFactory) Chains(testName string) ([]ibc.Chain, error) {
 			return nil, fmt.Errorf("failed to build chain config at index %d: %w", i, err)
 		}
 
-		chain, err := buildChain(f.log, testName, *cfg, s.NumValidators, s.NumFullNodes)
+		chain, err := buildChain(f.log, testName, *cfg, s.NumValidators, s.NumFullNodes, s.ExtraFlags)
 		if err != nil {
 			return nil, err
 		}
@@ -115,7 +115,7 @@ const (
 	defaultNumFullNodes  = 1
 )
 
-func buildChain(log *zap.Logger, testName string, cfg ibc.ChainConfig, numValidators, numFullNodes *int) (ibc.Chain, error) {
+func buildChain(log *zap.Logger, testName string, cfg ibc.ChainConfig, numValidators, numFullNodes *int, extraFlags map[string]interface{}) (ibc.Chain, error) {
 	nv := defaultNumValidators
 	if numValidators != nil {
 		nv = *numValidators
@@ -128,9 +128,9 @@ func buildChain(log *zap.Logger, testName string, cfg ibc.ChainConfig, numValida
 	chainType := strings.Split(cfg.Type, "-")
 
 	if chainType[0] == "rollapp" {
-		return rollapp.NewRollApp(testName, cfg, nv, nf, log), nil
+		return rollapp.NewRollApp(testName, cfg, nv, nf, log, extraFlags), nil
 	} else if chainType[0] == "hub" {
-		return hub.NewHub(testName, cfg, nv, nf, log), nil
+		return hub.NewHub(testName, cfg, nv, nf, log, extraFlags), nil
 	}
 
 	return cosmos.NewCosmosChain(testName, cfg, nv, nf, log), nil

--- a/chainspec.go
+++ b/chainspec.go
@@ -40,6 +40,9 @@ type ChainSpec struct {
 	// If unspecified, NumValidators defaults to 2 and NumFullNodes defaults to 1.
 	NumValidators, NumFullNodes *int
 
+	// ExtraFlags appends additional flags when starting the chain.
+	ExtraFlags map[string]interface{}
+
 	// Generate the automatic suffix on demand when needed.
 	autoSuffixOnce sync.Once
 	autoSuffix     string

--- a/cosmos/hub/dym_hub/dym_hub.go
+++ b/cosmos/hub/dym_hub/dym_hub.go
@@ -12,7 +12,8 @@ import (
 
 type DymHub struct {
 	*cosmos.CosmosChain
-	rollApp ibc.RollApp
+	rollApp    ibc.RollApp
+	extraFlags map[string]interface{}
 }
 
 var _ ibc.Chain = (*DymHub)(nil)
@@ -23,11 +24,12 @@ const (
 	maxSequencers = "5"
 )
 
-func NewDymHub(testName string, chainConfig ibc.ChainConfig, numValidators int, numFullNodes int, log *zap.Logger) *DymHub {
+func NewDymHub(testName string, chainConfig ibc.ChainConfig, numValidators int, numFullNodes int, log *zap.Logger, extraFlags map[string]interface{}) *DymHub {
 	cosmosChain := cosmos.NewCosmosChain(testName, chainConfig, numValidators, numFullNodes, log)
 
 	c := &DymHub{
 		CosmosChain: cosmosChain,
+		extraFlags:  extraFlags,
 	}
 
 	return c
@@ -66,9 +68,16 @@ func (c *DymHub) Start(testName string, ctx context.Context, additionalGenesisWa
 		return err
 	}
 
-	if err := c.RegisterRollAppToHub(ctx, sequencerName, rollAppChainID, maxSequencers, keyDir); err != nil {
+	// TODO: custom to create genesis_accounts.json that will pass in the rollapp
+	hasFlagGenesisPath, ok := c.extraFlags["genesis-accounts-path"].(bool)
+	flags := map[string]string{}
+	if hasFlagGenesisPath && ok {
+		flags["genesis-accounts-path"] = c.rollApp.GetHomeDir() + "/genesis_accounts.json"
+	}
+	if err := c.RegisterRollAppToHub(ctx, sequencerName, rollAppChainID, maxSequencers, keyDir, flags); err != nil {
 		return fmt.Errorf("failed to start chain %s: %w", c.Config().Name, err)
 	}
+
 	if err := c.RegisterSequencerToHub(ctx, sequencerName, rollAppChainID, maxSequencers, seq, keyDir); err != nil {
 		return fmt.Errorf("failed to start chain %s: %w", c.Config().Name, err)
 	}
@@ -81,8 +90,8 @@ func (c *DymHub) RegisterSequencerToHub(ctx context.Context, keyName, rollappCha
 }
 
 // RegisterRollAppToHub register rollapp on settlement.
-func (c *DymHub) RegisterRollAppToHub(ctx context.Context, keyName, rollappChainID, maxSequencers, keyDir string) error {
-	return c.GetNode().RegisterRollAppToHub(ctx, keyName, rollappChainID, maxSequencers, keyDir)
+func (c *DymHub) RegisterRollAppToHub(ctx context.Context, keyName, rollappChainID, maxSequencers, keyDir string, flags map[string]string) error {
+	return c.GetNode().RegisterRollAppToHub(ctx, keyName, rollappChainID, maxSequencers, keyDir, flags)
 }
 
 func (c *DymHub) SetRollApp(rollApp ibc.RollApp) {

--- a/cosmos/hub/dym_hub/dym_hub.go
+++ b/cosmos/hub/dym_hub/dym_hub.go
@@ -68,7 +68,6 @@ func (c *DymHub) Start(testName string, ctx context.Context, additionalGenesisWa
 		return err
 	}
 
-	// TODO: custom to create genesis_accounts.json that will pass in the rollapp
 	hasFlagGenesisPath, ok := c.extraFlags["genesis-accounts-path"].(bool)
 	flags := map[string]string{}
 	if hasFlagGenesisPath && ok {

--- a/cosmos/hub/dym_hub/dym_hub.go
+++ b/cosmos/hub/dym_hub/dym_hub.go
@@ -71,7 +71,7 @@ func (c *DymHub) Start(testName string, ctx context.Context, additionalGenesisWa
 	hasFlagGenesisPath, ok := c.extraFlags["genesis-accounts-path"].(bool)
 	flags := map[string]string{}
 	if hasFlagGenesisPath && ok {
-		flags["genesis-accounts-path"] = c.rollApp.GetHomeDir() + "/genesis_accounts.json"
+		flags["genesis-accounts-path"] = c.rollApp.(ibc.Chain).HomeDir() + "/genesis_accounts.json"
 	}
 	if err := c.RegisterRollAppToHub(ctx, sequencerName, rollAppChainID, maxSequencers, keyDir, flags); err != nil {
 		return fmt.Errorf("failed to start chain %s: %w", c.Config().Name, err)

--- a/cosmos/hub/hub.go
+++ b/cosmos/hub/hub.go
@@ -6,6 +6,6 @@ import (
 	"go.uber.org/zap"
 )
 
-func NewHub(testName string, chainConfig ibc.ChainConfig, numValidators int, numFullNodes int, log *zap.Logger) ibc.Chain {
-	return dym_hub.NewDymHub(testName, chainConfig, numValidators, numFullNodes, log)
+func NewHub(testName string, chainConfig ibc.ChainConfig, numValidators int, numFullNodes int, log *zap.Logger, extraFlags map[string]interface{}) ibc.Chain {
+	return dym_hub.NewDymHub(testName, chainConfig, numValidators, numFullNodes, log, extraFlags)
 }

--- a/cosmos/node.go
+++ b/cosmos/node.go
@@ -711,12 +711,15 @@ func (node *Node) GentxSeq(ctx context.Context, keyName string) error {
 	return err
 }
 
-func (node *Node) RegisterRollAppToHub(ctx context.Context, keyName, rollappChainID, maxSequencers, keyDir string) error {
+func (node *Node) RegisterRollAppToHub(ctx context.Context, keyName, rollappChainID, maxSequencers, keyDir string, flags map[string]string) error {
 	var command []string
 	detail := "{\"Addresses\":[]}"
 	keyPath := keyDir + "/sequencer_keys"
 	command = append(command, "rollapp", "create-rollapp", rollappChainID, maxSequencers, detail,
 		"--broadcast-mode", "block", "--keyring-dir", keyPath)
+	for flagName := range flags {
+		command = append(command, "--"+flagName, flags[flagName])
+	}
 	_, err := node.ExecTx(ctx, keyName, command...)
 	return err
 }

--- a/cosmos/rollapp/dym_rollapp/dym_rollapp.go
+++ b/cosmos/rollapp/dym_rollapp/dym_rollapp.go
@@ -297,7 +297,3 @@ func (c *DymRollApp) GetSequencer() string {
 func (c *DymRollApp) GetSequencerKeyDir() string {
 	return c.sequencerKeyDir
 }
-
-func (c *DymRollApp) GetHomeDir() string {
-	return c.HomeDir()
-}

--- a/cosmos/rollapp/rollapp.go
+++ b/cosmos/rollapp/rollapp.go
@@ -6,6 +6,6 @@ import (
 	"go.uber.org/zap"
 )
 
-func NewRollApp(testName string, chainConfig ibc.ChainConfig, numValidators int, numFullNodes int, log *zap.Logger) ibc.Chain {
-	return dym_rollapp.NewDymRollApp(testName, chainConfig, numValidators, numFullNodes, log)
+func NewRollApp(testName string, chainConfig ibc.ChainConfig, numValidators int, numFullNodes int, log *zap.Logger, extraFlags map[string]interface{}) ibc.Chain {
+	return dym_rollapp.NewDymRollApp(testName, chainConfig, numValidators, numFullNodes, log, extraFlags)
 }

--- a/ibc/chain.go
+++ b/ibc/chain.go
@@ -97,7 +97,7 @@ type Chain interface {
 
 type Hub interface {
 	// Register RollApp to Hub
-	RegisterRollAppToHub(ctx context.Context, keyName, rollappChainID, maxSequencers, keyDir string) error
+	RegisterRollAppToHub(ctx context.Context, keyName, rollappChainID, maxSequencers, keyDir string, flags map[string]string) error
 	// Register Sequencer to Hub
 	RegisterSequencerToHub(ctx context.Context, keyName, rollappChainID, maxSequencers, seq, keyDir string) error
 	// Set RollApp to Hub
@@ -115,6 +115,8 @@ type RollApp interface {
 	ShowSequencer(ctx context.Context) (string, error)
 	// Get Sequencer
 	GetSequencer() string
+	// Get Validator Genesis Dir
+	GetHomeDir() string
 }
 
 // TransferOptions defines the options for an IBC packet transfer.

--- a/ibc/chain.go
+++ b/ibc/chain.go
@@ -115,8 +115,6 @@ type RollApp interface {
 	ShowSequencer(ctx context.Context) (string, error)
 	// Get Sequencer
 	GetSequencer() string
-	// Get Validator Genesis Dir
-	GetHomeDir() string
 }
 
 // TransferOptions defines the options for an IBC packet transfer.


### PR DESCRIPTION
According to [PR642](https://github.com/dymensionxyz/dymension/blob/a62000dfbc8569f907bde560b29a71cefe83d532/x/rollapp/client/cli/tx_create_rollapp.go#L56-L59), there is an extra flag that been add when calling CreateRollapp. In order to add this into the rollup-e2e-testing and future improvement on adding different config when start chain, this PR is created to add an ExtraFlags on ChainSpecs. 